### PR TITLE
Bugfix/4-1 日付フォーマットの変更、従業員一覧の並び順

### DIFF
--- a/src/main/java/com/example/domain/Employee.java
+++ b/src/main/java/com/example/domain/Employee.java
@@ -173,15 +173,6 @@ public class Employee {
 		this.dependentsCount = dependentsCount;
 	}
 
-  public String getFormattedHireDate() {
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy年MM月dd日");
-    return sdf.format(hireDate);
-  }
-
-  public String getFormattedSalary() {
-	NumberFormat salaryformat =  new DecimalFormat("###,###");
-	return salaryformat.format(salary);
-  }
 
   
 	@Override

--- a/src/main/java/com/example/domain/Employee.java
+++ b/src/main/java/com/example/domain/Employee.java
@@ -1,5 +1,7 @@
 package com.example.domain;
 
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -174,6 +176,11 @@ public class Employee {
   public String getFormattedHireDate() {
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy年MM月dd日");
     return sdf.format(hireDate);
+  }
+
+  public String getFormattedSalary() {
+	NumberFormat salaryformat =  new DecimalFormat("###,###");
+	return salaryformat.format(salary);
   }
 
   

--- a/src/main/java/com/example/domain/Employee.java
+++ b/src/main/java/com/example/domain/Employee.java
@@ -1,5 +1,6 @@
 package com.example.domain;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -170,6 +171,12 @@ public class Employee {
 		this.dependentsCount = dependentsCount;
 	}
 
+  public String getFormattedHireDate() {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy年MM月dd日");
+    return sdf.format(hireDate);
+  }
+
+  
 	@Override
 	public String toString() {
 		return "Employee [id=" + id + ", name=" + name + ", image=" + image + ", gender=" + gender + ", hireDate="

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -45,12 +45,12 @@ public class EmployeeRepository {
 	private NamedParameterJdbcTemplate template;
 
 	/**
-	 * 従業員一覧情報を入社日順で取得します.
+	 * 従業員一覧情報を入社日が新しい順で取得します
 	 * 
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
 	public List<Employee> findAll() {
-		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees";
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC";
 
 		List<Employee> developmentList = template.query(sql, EMPLOYEE_ROW_MAPPER);
 

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -50,7 +50,7 @@ public class EmployeeRepository {
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
 	public List<Employee> findAll() {
-		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC";
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC, name ASC";
 
 		List<Employee> developmentList = template.query(sql, EMPLOYEE_ROW_MAPPER);
 

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -50,7 +50,7 @@ public class EmployeeRepository {
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
 	public List<Employee> findAll() {
-		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC, name ASC";
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC, mail_address ASC";
 
 		List<Employee> developmentList = template.query(sql, EMPLOYEE_ROW_MAPPER);
 

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -45,7 +45,7 @@ public class EmployeeRepository {
 	private NamedParameterJdbcTemplate template;
 
 	/**
-	 * 従業員一覧情報を入社日が新しい順で取得します
+	 * 従業員一覧情報を入社日が新しい順,アドレスの昇順で取得します
 	 * 
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:utext="${employee.formattedSalary + '円'}">400000円</span>
                     </td>
                   </tr>
                   <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -132,7 +132,7 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${employee.formattedHireDate}">2012年11月29日</span>
+                      <span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012年11月29日</span>
                     </td>
                   </tr>
                   <tr>
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.formattedSalary + '円'}">400000円</span>
+                      <span th:utext="${#numbers.formatInteger(employee.salary, 3, 'COMMA')}">400000円</span>
                     </td>
                   </tr>
                   <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -132,7 +132,7 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${employee.hireDate}">2012/11/29</span>
+                      <span th:utext="${employee.formattedHireDate}">2012/11/29</span>
                     </td>
                   </tr>
                   <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -132,7 +132,7 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${employee.formattedHireDate}">2012/11/29</span>
+                      <span th:utext="${employee.formattedHireDate}">2012年11月29日</span>
                     </td>
                   </tr>
                   <tr>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -117,7 +117,7 @@
                   </a>
                 </td>
                 <td>
-                  <span th:text="${employee.hireDate}">2016/12/1</span>
+                  <span th:text="${employee.formattedHireDate}">2016年12月1日</span>
                 </td>
                 <td>
                   <span th:text="${employee.dependentsCount} + '人'">3人</span>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -117,7 +117,7 @@
                   </a>
                 </td>
                 <td>
-                  <span th:text="${employee.formattedHireDate}">2016年12月1日</span>
+                  <span th:text="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2016年12月1日</span>
                 </td>
                 <td>
                   <span th:text="${employee.dependentsCount} + '人'">3人</span>


### PR DESCRIPTION
【従業員一覧ページ】
3-1：従業員一覧の並び順
入社日が新しい順、アドレスの昇順で表示するように変更しました。
3-2：日付フォーマット
「yyyy/mm/dd」→「yyyy年mm月dd日」

【従業員詳細ページ】
4-1：日付フォーマット
「yyyy/mm/dd」→「yyyy年mm月dd日」

前回送ったbranchの変更内容が私が思っていた内容と違ったみたいです。すみません。
把握があいまいになってしまったので今回の4-1で、3-1,3-2,4-1の変更がまとまってます！
大変申し訳ないのですがまとめてご確認お願いします。