### PR TITLE
Bugfix/4-3

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -84,7 +84,9 @@
 
       <!-- パンくずリスト -->
       <ol class="breadcrumb">
-        <li>従業員リスト</li>
+        <li>
+          <a href="list.html" th:href="@{/employee/showList}">従業員リスト</a>
+        </li>
         <li class="active">従業員詳細</li>
       </ol>
 

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -84,7 +84,7 @@
 
       <!-- パンくずリスト -->
       <ol class="breadcrumb">
-        <li class="active">
+        <li>
           <a href="list.html" th:href="@{/employee/showList}">従業員リスト</a>
         </li>
       </ol>


### PR DESCRIPTION
4-3
【パンくずリスト修正】
従業員一覧に戻るリンクを修正して、従業員詳細画面から従業員にリストをクリックで一覧画面に戻れるよう修正しました。

確認お願いいたします。